### PR TITLE
fix: try to use latest git for colour-science package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ asyncio = "==3.4.3"
 websockets = "==8.1"
 colour-demosaicing = "==0.1.6"
 pillow = "==8.0.1"
+colour = {git = "https://github.com/colour-science/colour"}
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eb4ca967175561b18288cdc1fe4181a55f1d239673744f9cf843f8dcfb774c57"
+            "sha256": "4e3a82fe817fc4e2a0bdf0c5c5451b181cea206b80e83328931114437f7d82ed"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -111,6 +111,10 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
+        },
+        "colour": {
+            "git": "https://github.com/colour-science/colour",
+            "ref": "74a6cc01f514fc557cf026970cf9d91b2518d717"
         },
         "colour-demosaicing": {
             "hashes": [


### PR DESCRIPTION
This is a bandaid until https://github.com/colour-science/colour/issues/663 is released.